### PR TITLE
Use SVG kickoff illustrations and refresh meeting schedule

### DIFF
--- a/public/assets/home/gallery/kickoff_2024_photo1.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo1.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Fall 2024 Kickoff welcome graphic</title>
+  <desc id="desc">Stylized illustration representing the AI Club Fall 2024 kickoff in the Makerspace.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1B1F3B" />
+      <stop offset="50%" stop-color="#5036A3" />
+      <stop offset="100%" stop-color="#FF7A99" />
+    </linearGradient>
+    <radialGradient id="glow" cx="60%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FFE29A" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#FFE29A" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="48" />
+  <circle cx="780" cy="320" r="320" fill="url(#glow)" />
+  <g fill="none" stroke="#FFFFFF" stroke-opacity="0.35">
+    <rect x="160" y="200" width="880" height="420" rx="36" stroke-width="4" />
+    <rect x="200" y="240" width="800" height="340" rx="28" stroke-width="2" />
+    <path d="M220 520 h760" stroke-width="2" stroke-dasharray="12 18" />
+  </g>
+  <g fill="#FFFFFF">
+    <text x="200" y="310" font-size="64" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" letter-spacing="4">FALL 2024 KICKOFF</text>
+    <text x="200" y="390" font-size="48" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="600">Welcome to the Makerspace</text>
+    <text x="200" y="470" font-size="28" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.9">New faces, collaborative energy, and community projects take flight.</text>
+  </g>
+  <g fill="#FFE29A" opacity="0.9">
+    <circle cx="1020" cy="180" r="14" />
+    <circle cx="1048" cy="220" r="10" />
+    <circle cx="980" cy="210" r="8" />
+    <circle cx="940" cy="170" r="6" />
+  </g>
+  <g fill="#8CF4FF" opacity="0.7">
+    <circle cx="320" cy="600" r="14" />
+    <circle cx="360" cy="640" r="10" />
+    <circle cx="280" cy="640" r="6" />
+    <circle cx="260" cy="590" r="8" />
+  </g>
+</svg>

--- a/public/assets/home/gallery/kickoff_2024_photo2.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Kickoff conversations illustration</title>
+  <desc id="desc">Abstract illustration of members connecting before the kickoff meeting.</desc>
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0F2027" />
+      <stop offset="45%" stop-color="#203A43" />
+      <stop offset="100%" stop-color="#2C5364" />
+    </linearGradient>
+    <linearGradient id="wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#63D6FF" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#C58CFF" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg2)" rx="48" />
+  <path d="M0 520 C200 420, 420 580, 620 500 C820 420, 1000 560, 1200 460 V800 H0 Z" fill="url(#wave)" opacity="0.65" />
+  <g fill="#FFFFFF" opacity="0.8">
+    <circle cx="360" cy="370" r="120" />
+    <circle cx="520" cy="340" r="90" />
+    <circle cx="700" cy="380" r="110" />
+    <circle cx="860" cy="350" r="80" />
+  </g>
+  <g fill="none" stroke="#63D6FF" stroke-width="6" stroke-linecap="round" opacity="0.8">
+    <path d="M360 370 Q440 300 520 340" />
+    <path d="M520 340 Q620 420 700 380" />
+    <path d="M700 380 Q780 300 860 350" />
+  </g>
+  <g fill="#F8FBFF">
+    <text x="150" y="610" font-size="56" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">Kickoff Connections</text>
+    <text x="150" y="670" font-size="32" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Members gathering, greeting, and getting ready to collaborate.</text>
+  </g>
+</svg>

--- a/public/assets/home/gallery/kickoff_2024_photo3.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Kickoff workshop energy illustration</title>
+  <desc id="desc">Abstract depiction of brainstorming during the kickoff workshop.</desc>
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#23074D" />
+      <stop offset="100%" stop-color="#CC5333" />
+    </linearGradient>
+    <radialGradient id="idea" cx="30%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#FFFACD" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#FFD166" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#FFD166" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg3)" rx="48" />
+  <circle cx="420" cy="320" r="280" fill="url(#idea)" />
+  <g stroke="#FFE29A" stroke-width="10" stroke-linecap="round" stroke-dasharray="6 24" opacity="0.75">
+    <path d="M420 120 L420 520" />
+    <path d="M220 320 L620 320" />
+    <path d="M300 190 L540 450" />
+    <path d="M540 190 L300 450" />
+  </g>
+  <g fill="#FFFFFF">
+    <path d="M760 220 h200 a24 24 0 0 1 24 24 v120 a24 24 0 0 1 -24 24 h-120 l-60 72 v-72 h-20 a24 24 0 0 1 -24 -24 v-120 a24 24 0 0 1 24 -24 z" opacity="0.85" />
+    <text x="800" y="305" font-size="48" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">IDEAS</text>
+    <text x="800" y="360" font-size="28" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Brainstorming sparks</text>
+  </g>
+  <g fill="#FFF" opacity="0.9">
+    <text x="150" y="650" font-size="54" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">Workshop Energy</text>
+    <text x="150" y="705" font-size="30" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Creative problem solving during kickoff activities.</text>
+  </g>
+</svg>

--- a/public/assets/home/gallery/kickoff_2024_photo4.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo4.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Makerspace collaboration illustration</title>
+  <desc id="desc">Abstract representation of students collaborating in the Makerspace.</desc>
+  <defs>
+    <linearGradient id="bg4" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#101728" />
+      <stop offset="50%" stop-color="#1F4068" />
+      <stop offset="100%" stop-color="#5C7AEA" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg4)" rx="48" />
+  <g fill="none" stroke="#9EC9FF" stroke-width="6" stroke-linejoin="round" opacity="0.8">
+    <path d="M220 260 h760 v280 h-760 z" />
+    <path d="M260 300 h680 v200 h-680 z" />
+    <path d="M340 300 v200" />
+    <path d="M860 300 v200" />
+    <path d="M500 340 l80 -40 80 40" />
+    <path d="M500 460 l80 40 80 -40" />
+  </g>
+  <g fill="#E2F3FF" opacity="0.85">
+    <circle cx="360" cy="400" r="36" />
+    <circle cx="840" cy="400" r="36" />
+    <circle cx="600" cy="360" r="44" />
+    <circle cx="600" cy="460" r="44" />
+  </g>
+  <g fill="#FFFFFF">
+    <text x="160" y="620" font-size="58" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">Makerspace Vibes</text>
+    <text x="160" y="680" font-size="32" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Hands-on collaboration around the work tables.</text>
+  </g>
+</svg>

--- a/public/assets/home/gallery/kickoff_2024_photo5.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo5.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Kickoff candid smiles illustration</title>
+  <desc id="desc">Playful illustration showing candid smiles from the kickoff event.</desc>
+  <defs>
+    <linearGradient id="bg5" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2C061F" />
+      <stop offset="50%" stop-color="#6F2232" />
+      <stop offset="100%" stop-color="#C3073F" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg5)" rx="48" />
+  <g fill="#FFE8A3" opacity="0.85">
+    <circle cx="360" cy="360" r="120" />
+    <circle cx="520" cy="320" r="80" />
+    <circle cx="720" cy="360" r="120" />
+    <circle cx="900" cy="340" r="90" />
+  </g>
+  <g fill="none" stroke="#2C061F" stroke-width="10" stroke-linecap="round" opacity="0.9">
+    <path d="M320 360 q40 80 80 0" />
+    <path d="M680 360 q40 80 80 0" />
+    <path d="M880 340 q30 60 60 0" />
+  </g>
+  <g fill="#FFFFFF">
+    <text x="160" y="620" font-size="58" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">Kickoff Candid</text>
+    <text x="160" y="680" font-size="32" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Smiles from our first meeting of the season.</text>
+  </g>
+</svg>

--- a/public/assets/home/gallery/kickoff_2024_photo6.svg
+++ b/public/assets/home/gallery/kickoff_2024_photo6.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Kickoff launch illustration</title>
+  <desc id="desc">Stylized representation of club officers preparing for the new weekly series.</desc>
+  <defs>
+    <linearGradient id="bg6" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B132B" />
+      <stop offset="40%" stop-color="#1C2541" />
+      <stop offset="100%" stop-color="#3A506B" />
+    </linearGradient>
+    <linearGradient id="rocket" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#E0F6FF" />
+      <stop offset="100%" stop-color="#8CCBFF" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg6)" rx="48" />
+  <g opacity="0.6" fill="#5BC0BE">
+    <circle cx="240" cy="220" r="60" />
+    <circle cx="340" cy="180" r="40" />
+    <circle cx="900" cy="200" r="80" />
+    <circle cx="1020" cy="260" r="50" />
+  </g>
+  <g>
+    <path d="M600 220 l80 160 h-60 v200 h-40 v-200 h-60 z" fill="url(#rocket)" />
+    <path d="M620 640 c-32 -60 -120 -40 -140 20 40 -20 80 -10 120 40 40 -50 80 -60 120 -40 -20 -60 -108 -80 -140 -20z" fill="#FF6B6B" opacity="0.85" />
+  </g>
+  <g fill="#FFFFFF">
+    <text x="160" y="620" font-size="56" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700">Ready for Launch</text>
+    <text x="160" y="680" font-size="30" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="500" fill-opacity="0.85">Officers gearing up for the weekly series.</text>
+  </g>
+</svg>

--- a/src/app/shared/InfoHub.tsx
+++ b/src/app/shared/InfoHub.tsx
@@ -2,43 +2,41 @@ import React from 'react'
 
 import Link from 'next/link'
 
-import { INFOHUB_MEETING_DAY, INFOHUB_MEETING_HOUR, INFOHUB_MEETING_LOCATION, INFOHUB_MEETING_LOCATION_LINK, INFOHUB_ANNOUNCEMENT } from '@/dispositions/general'
+import {
+    INFOHUB_MEETING_DAY,
+    INFOHUB_MEETING_LOCATION,
+    INFOHUB_MEETING_LOCATION_LINK,
+    INFOHUB_FIRST_MEETING_DATE,
+    INFOHUB_ANNOUNCEMENT,
+} from '@/dispositions/general'
 
 import { PiToiletPaperDuotone } from 'react-icons/pi'
 
 import { Countdown } from 'shared/_modules'
 import Socials from 'shared/Socials'
 
-function getNextBiWeeklyMeeting() {
-    // First meeting is September 17, 2025
-    const firstMeeting = new Date('2025-09-17T18:00:00-07:00')
+function getNextWeeklyMeeting(): Date {
+    const firstMeeting = new Date(INFOHUB_FIRST_MEETING_DATE)
     const currentDate = new Date()
-    
-    // If current date is before first meeting, return first meeting
-    if (currentDate < firstMeeting) {
-        return firstMeeting.toLocaleDateString()
+
+    if (currentDate <= firstMeeting) {
+        return firstMeeting
     }
-    
-    // Calculate weeks since first meeting
-    const msPerWeek = 7 * 24 * 60 * 60 * 1000
-    const weeksSinceFirst = Math.floor((currentDate.getTime() - firstMeeting.getTime()) / msPerWeek)
-    
-    // Find next bi-weekly meeting (every 2 weeks)
-    const nextMeetingWeeks = Math.ceil(weeksSinceFirst / 2) * 2
-    const nextMeetingDate = new Date(firstMeeting.getTime() + (nextMeetingWeeks * msPerWeek))
-    
-    // If the calculated date is in the past or today, move to next bi-weekly meeting
-    if (nextMeetingDate <= currentDate) {
-        nextMeetingDate.setDate(nextMeetingDate.getDate() + 14)
+
+    const nextMeeting = new Date(firstMeeting)
+
+    while (nextMeeting <= currentDate) {
+        nextMeeting.setDate(nextMeeting.getDate() + 7)
     }
-    
-    return nextMeetingDate.toLocaleDateString()
+
+    return nextMeeting
 }
 
-const nextMeetingDate = getNextBiWeeklyMeeting()
+const nextMeetingDate = getNextWeeklyMeeting()
+const nextMeetingDateLabel = nextMeetingDate.toLocaleDateString()
 const nextMeetingDay = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][INFOHUB_MEETING_DAY]
 
-const meetingTimeFormattedHour = new Date(nextMeetingDate + ' ' + INFOHUB_MEETING_HOUR).toLocaleTimeString('en', { hour: '2-digit', minute:'2-digit' })
+const meetingTimeFormattedHour = nextMeetingDate.toLocaleTimeString('en', { hour: 'numeric', minute: '2-digit' })
 
 export function InfoHub(): React.ReactNode {
     return (
@@ -63,15 +61,15 @@ export function InfoHub(): React.ReactNode {
                     <div>
                         <h2 className='title-main text-neutral-400 font-semibold'>⏰ WHEN</h2>
                         <h2 className='title-main text-3xl font-semibold pr-0 md:pr-16'>
-                            Bi-Weekly, <span className='text-[#FCD690] font-bold'>{nextMeetingDay}s</span> at <span className='text-blue-200 font-bold'>{meetingTimeFormattedHour}</span>
+                            Weekly, <span className='text-[#FCD690] font-bold'>{nextMeetingDay}s</span> at <span className='text-blue-200 font-bold'>{meetingTimeFormattedHour}</span>
                         </h2>
                         <div className='text-neutral-400 text-sm italic'>
                             (Subject to change)
                         </div>
                         <div className='text-neutral-300'>
-                            Next meeting will be on <span className='underline underline-offset-2'>{nextMeetingDate}</span> which is in:
+                            Next meeting will be on <span className='underline underline-offset-2'>{nextMeetingDateLabel}</span> which is in:
                         </div>
-                        <Countdown timestamp={new Date(`${nextMeetingDate} ${INFOHUB_MEETING_HOUR}`).getTime()} className='my-4'/>
+                        <Countdown timestamp={nextMeetingDate.getTime()} className='my-4'/>
                     </div>
 
                     <div>
@@ -85,7 +83,7 @@ export function InfoHub(): React.ReactNode {
                             You can also tune-in remotely on our{' '}
                             <Link href='https://discord.gg/tDtqmP5sGt' target='_blank' className='text-purple-400 font-semibold'>Discord</Link> Stage.
                         </div>
-                        <Link href='https://calendar.google.com/calendar/render?action=TEMPLATE&text=%F0%9F%A4%96+AI+Club+Meeting!+%F0%9F%A4%96&dates=20250917T180000/20250917T200000&ctz=America/Los_Angeles&location=Location+TBA&details=Bi-weekly%20AI%20Club%20meeting.%20All%20are%20welcome!%20To%20see%20the%20agenda%20for%20our%20meeting%2C%20please%20see%20the%20discord%20%23announcements%20channel!%20https%3A%2F%2Fdiscord.gg%2FPH7KxjPz24&recur=RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE' target='_blank'>
+                        <Link href='https://calendar.google.com/calendar/render?action=TEMPLATE&text=%F0%9F%A4%96+AI+Club+Meeting!+%F0%9F%A4%96&dates=20251006T180000/20251006T190000&ctz=America/Los_Angeles&location=Makerspace+(LIB+260)%2C+SFSU&details=Weekly%20AI%20Club%20meeting.%20All%20are%20welcome!%20Check%20the%20Discord%20%23announcements%20channel%20for%20agendas.%20https%3A%2F%2Fdiscord.gg%2FPH7KxjPz24&recur=RRULE:FREQ=WEEKLY;BYDAY=MO' target='_blank'>
                             <p className='w-52 hover:w-56 transition-all p-2 my-2 text-sm text-center font-semibold hover:animate-pulse bg-yellow-900 rounded-lg'>🔔 Sign up for reminders!</p>
                         </Link>
                     </div>

--- a/src/dispositions/gallery.ts
+++ b/src/dispositions/gallery.ts
@@ -16,6 +16,30 @@ interface GalleryPiece {
 
 export const HomeAlbum: GalleryPiece[] = [
     {
+        remark: '🎉 Fall 2024 Kickoff Meeting – Welcome to the Makerspace',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo1.svg',
+    },
+    {
+        remark: '🤝 Kickoff Connections – Members settling in before the meeting',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo2.svg',
+    },
+    {
+        remark: '🧠 Workshop Energy – Brainstorming during our kickoff activities',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo3.svg',
+    },
+    {
+        remark: '🙌 Makerspace Vibes – Collaborating around the work tables',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo4.svg',
+    },
+    {
+        remark: '📸 Kickoff Candid – Smiles from our first meeting of the season',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo5.svg',
+    },
+    {
+        remark: '🚀 Ready for Launch – Club officers gearing up for the weekly series',
+        imgSrc: DIR_HOME_GALLERY + 'kickoff_2024_photo6.svg',
+    },
+    {
         remark: '🌄 "Expand Your Horizons 2022"\nTinkerCAD 3D Design Printing',
         imgSrc: DIR_HOME_GALLERY + 'expand_print_closeup.jpg',
     },

--- a/src/dispositions/general.tsx
+++ b/src/dispositions/general.tsx
@@ -6,10 +6,12 @@ export const ANNOUNCEMENT_TEXT: string = '🚧 This website is undergoing consta
 export const ANNOUNCEMENT_GRAD_COLOR: string = 'from-[#553E00FF]'
 
 // Overview section for info regarding our meetings
-export const INFOHUB_MEETING_DAY: number = 3 // The day of the week, from [0-6] with 0 being Sunday (3 = Wednesday)
+export const INFOHUB_MEETING_DAY: number = 1 // The day of the week, from [0-6] with 0 being Sunday (1 = Monday)
 export const INFOHUB_MEETING_HOUR: string = '18:00' // Uses 24-hour time format, i.e "12:34" (18:00 = 6pm)
-export const INFOHUB_MEETING_LOCATION: string = 'TBA @ SFSU' // Uses "Building #, Room #-###" format for min ambiguity
-export const INFOHUB_MEETING_LOCATION_LINK: string = 'https://maps.app.goo.gl/bjWJEroRLzsDPYcGA' // URL to a preferrably Google Maps index of our meeting location
+export const INFOHUB_MEETING_LOCATION: string = 'Makerspace (LIB 260)' // Uses "Building #, Room #-###" format for min ambiguity
+export const INFOHUB_MEETING_LOCATION_LINK: string =
+    'https://maps.google.com/?q=Makerspace+(LIB+260)+San+Francisco+State+University' // URL to a preferrably Google Maps index of our meeting location
+export const INFOHUB_FIRST_MEETING_DATE: string = '2025-10-06T18:00:00-07:00'
 
 export const INFOHUB_ANNOUNCEMENT: React.ReactNode = (
     <>


### PR DESCRIPTION
## Summary
- replace the kickoff gallery images with lightweight SVG illustrations so no binary assets are added to the repo
- point the home gallery entries to the new SVG art while keeping the original captions
- keep the Info Hub weekly Makerspace schedule, countdown logic, and calendar invite updated for Fall 2024 meetings

## Testing
- yarn lint *(fails: workspace not in lockfile without running `yarn install`)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf6aba59c8327a4874fdd78c0ba75